### PR TITLE
EEH-2525 - Amended error in the markdown creation

### DIFF
--- a/.github/workflows/markdown_creation.yml
+++ b/.github/workflows/markdown_creation.yml
@@ -52,14 +52,17 @@ jobs:
 
       - name: Setup git config
         run: |
-          # Setup the username and email. No email by default
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          # Setup the username and email
+          git config --local user.name "GitHub Actions Bot"
+          git config --local user.email "action@github.com"
 
       - name: Add, commit and push to main
         run: |
           markdown_dir="./docs/json_browser/markdowns"
           today=$(date +%F)
+          # We add new additions
           git add $markdown_dir/*
+          # And add to stage the deleted files as well
+          git rm $(git ls-files --deleted "$markdown_dir")
           git commit -m "JSON Schemas to Markdown - $today"
           git push origin main


### PR DESCRIPTION
The error appeared when creating the markdowns created no new files, and simply removed a lot of them instead. Which was not caught by the staging command in the workflow.

## Ticket reference
EEH-2525

## Overall changes
- Added a command in the failing "run" to also add removed files. 
- Added email to the GitHub actions bot.

## Future TO-DOs and checks
- [X] Checked that the object's versions (i.e. ``meta:version``) are updated before creating the PR (see [GitHub Action](../.github/workflows/update_version_manifest.yml)). 
- [X] Checked that the version manifest is up to date right before merging (see [documentation](../docs/releases/README.md#updating-the-version-manifest)). 
- [ ] Check that, once the PR is merged, the GH action is triggered and the markdown files are modified as expected. 