### PR TITLE
EEH-2525 - Amend ``git rm``

### DIFF
--- a/.github/scripts/request_validation.py
+++ b/.github/scripts/request_validation.py
@@ -27,7 +27,7 @@ for file in os.scandir(dirname):
 
     request = request_validation(
         data_filepath=file,
-        curl_URL=curl_URL
+        validator_url=curl_URL
     )
 
     val_error = get_errors_response(

--- a/.github/scripts/utils/json_manipulation.py
+++ b/.github/scripts/utils/json_manipulation.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Union
 from .string_manipulation import add_newlines, \
     is_semantic_version, \
-    is_higher_version
+    is_higher_version, \
     replace_after_string_in_url
 
 # - #

--- a/.github/scripts/utils/json_validation.py
+++ b/.github/scripts/utils/json_validation.py
@@ -18,7 +18,7 @@ import jsonschema
 # Helper functions
 # -#
 def request_validation(
-    data_filepath: Union[str, os.DirEntry[str]], validator_url: str, headers: dict = None
+    data_filepath: str, validator_url: str, headers: dict = None
 ) -> requests.models.Response:
     """
     Function that, given a data_filepath (e.g. "path/to/file.json"), a validation URL (e.g. http://localhost:3020/validate)

--- a/.github/workflows/markdown_creation.yml
+++ b/.github/workflows/markdown_creation.yml
@@ -63,6 +63,9 @@ jobs:
           # We add new additions
           git add $markdown_dir/*
           # And add to stage the deleted files as well
-          git rm $(git ls-files --deleted "$markdown_dir")
+          deleted_files=$(git ls-files --deleted "$markdown_dir")
+          if [ -n "$deleted_files" ]; then
+            git rm $deleted_files
+          fi
           git commit -m "JSON Schemas to Markdown - $today"
           git push origin main


### PR DESCRIPTION
## Ticket reference

## Overall changes
- Amended the ``git rm`` command in the markdown creation, which was failing when there were no files to remove.


## Future TO-DOs and checks
- [x] Check that the object's versions (i.e. ``meta:version``) are updated before creating the PR (see [GitHub Action](../.github/workflows/update_version_manifest.yml)). 
- [x] Check that the version manifest is up to date right before merging (see [documentation](../docs/releases/README.md#updating-the-version-manifest)). 
